### PR TITLE
bugfix: Fix Scrollbar overriding Search Modal Container Styling

### DIFF
--- a/docs/_COMMIT_MESSAGE_TEMPLATE.md
+++ b/docs/_COMMIT_MESSAGE_TEMPLATE.md
@@ -1,0 +1,16 @@
+## GIT COMMIT MESSAGE TEMPLATE
+
+feat: Add EndpointResponse enum
+
+    This commit introduces a new enum, EndpointResponse, in service.types.ts. This enum provides a centralized location for managing API endpoints, improving maintainability and readability.
+
+    The following endpoints have been added:
+
+    - PREDICTIONS_RESPONSE
+    - SIGNPOST_TRAIN_RESPONSE
+    - RAIL_ARRIVAL_TIMES_RESPONSE
+    - GENERAL_STATION_RESPONSE
+    - AMENITIES_STATION_RESPONSE
+    - STATION_SCHEDULE_RESPONSE
+
+    This change will simplify the process of updating API endpoints in the future.

--- a/libs/features/navigation/src/ui/components/navigation/navigation.component.ts
+++ b/libs/features/navigation/src/ui/components/navigation/navigation.component.ts
@@ -14,5 +14,4 @@ import { StaticContentService } from '../../../data/index';
 export class NavigationComponent {
    constructor(private staticContent: StaticContentService) {}
    sideBarContent = this.staticContent.setSidebarContent();
-   
 }

--- a/libs/features/search/src/ui/components/search-modal/search-modal.component.scss
+++ b/libs/features/search/src/ui/components/search-modal/search-modal.component.scss
@@ -15,12 +15,21 @@
 .search-modal {
    background: #ffffff;
    padding-bottom: 24px;
-   overflow: scroll;
+   overflow: auto;
    height: 100vh;
    width: 100%;
    padding: 16px 24px 24px;
    border-radius: 0;
    box-shadow: 0px 4px 10px 0px rgba(57, 57, 57, 0.1);
+   scrollbar-color: #eff1f8 #f7f8fb;
+   scrollbar-width: thin;
+   -ms-overflow-style: none; /* IE and Edge */
+   scrollbar-width: none; /* Firefox */
+
+   &::-webkit-scrollbar {
+      width: 8px;
+      // display: none;
+   }
 
    rya-icon {
       display: block;


### PR DESCRIPTION
    This commit removes the scrollbar from the modal, in order to match the established Figma design.

    The following css properties have been added to .search-modal:
    - scrollbar-width
    -  scrollbar-color
    - -ms-overflow-style
    
## BEFORE   
![image](https://github.com/OscarViquez/atl-transit/assets/55415043/85d412d3-e6de-47da-9750-cb03a2e8f145)

## AFTER   
![image](https://github.com/OscarViquez/atl-transit/assets/55415043/8addb0f1-fc65-499a-a343-66f29fbfcc13)
