### PR TITLE
bugfix: add default text color for rya-button class selector

### DIFF
--- a/libs/assets/styles/directives/button-directive.css
+++ b/libs/assets/styles/directives/button-directive.css
@@ -5,6 +5,7 @@
 .rya-button {
    display: var(--rya-display-inline-flex);
    gap: var(--rya-space-3); /* 12px */
+   color: var(--rya-text-primary);
    align-items: center;
    justify-content: center;
    transition: all 0.2s ease-in-out;

--- a/src/index.html
+++ b/src/index.html
@@ -16,9 +16,9 @@
       <link rel="apple-touch-icon" sizes="180x180" href="pwa/apple-touch-icon.png" />
       <link rel="icon" type="image/png" sizes="32x32" href="pwa/favicon-32x32.png" />
       <link rel="icon" type="image/png" sizes="16x16" href="pwa/favicon-16x16.png" />
-      <link rel="mask-icon" href="pwa/safari-pinned-tab.svg" color="#5bbad5" />
-      <meta name="msapplication-TileColor" content="#da532c" />
-      <meta name="theme-color" content="#F2834C" />
+      <link rel="mask-icon" href="pwa/safari-pinned-tab.svg" color="#f8f8f8" />
+      <meta name="msapplication-TileColor" content="#f8f8f8" />
+      <meta name="theme-color" content="#f8f8f8" />
       <link rel="manifest" href="/manifest.json" />
    </head>
    <body>


### PR DESCRIPTION
Changes include the following
- button-directive.css: Adding primary text color as the default text color for button directive.
-  index.html: changing the color of background and tabs when user visit websites on iOS and Desktop browser.


## ISSUE: 
<img src="https://github.com/OscarViquez/atl-transit/assets/55415043/bc7802e1-6a04-4b3a-9c23-4247d51c802b" width="400">


## SOLUTION: 